### PR TITLE
Implement `allowedSharedLocalDependencies` checks

### DIFF
--- a/Sources/Core/DependenciesValidator.swift
+++ b/Sources/Core/DependenciesValidator.swift
@@ -11,6 +11,10 @@ struct DependenciesValidator {
         self.allowedSharedLocalDependencies = Set(allowedSharedLocalDependencies)
     }
     
+    /// Validates that all local dependencies of the given spec are allowed shared local dependencies.
+    ///
+    /// - Parameter spec: The `Spec` instance whose local dependencies will be validated.
+    /// - Throws: `DependenciesValidatorError.disallowedSharedLocalDependency` if a local dependency is not in the allowed list.
     func validateSharedLocalDependencies(_ spec: Spec) throws {
         for dependency in spec.localDependencies {
             guard allowedSharedLocalDependencies.contains(dependency.name) else {

--- a/Sources/Core/DependenciesValidator.swift
+++ b/Sources/Core/DependenciesValidator.swift
@@ -1,0 +1,44 @@
+//  DependenciesValidatorError.swift
+
+import Foundation
+import ArgumentParser
+
+struct DependenciesValidator {
+    
+    private let allowedSharedLocalDependencies: Set<String>
+    
+    init(allowedSharedLocalDependencies: [String]) {
+        self.allowedSharedLocalDependencies = Set(allowedSharedLocalDependencies)
+    }
+    
+    func validateSharedLocalDependencies(_ spec: Spec) throws {
+        for dependency in spec.localDependencies {
+            guard allowedSharedLocalDependencies.contains(dependency.name) else {
+                throw DependenciesValidatorError.disallowedSharedLocalDependency(
+                    moduleName: spec.name,
+                    localDependencyName: dependency.name,
+                    allowedSharedLocalDependencies: allowedSharedLocalDependencies
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Error Definitions
+
+enum DependenciesValidatorError: LocalizedError {
+    
+    case disallowedSharedLocalDependency(
+        moduleName: String,
+        localDependencyName: String,
+        allowedSharedLocalDependencies: Set<String>
+    )
+    
+    var errorDescription: String? {
+        switch self {
+        case let .disallowedSharedLocalDependency(moduleName, localDependencyName, allowedSharedLocalDependencies):
+            let allowedSharedLocalDependenciesList = allowedSharedLocalDependencies.joined(separator: ", ")
+            return "'\(moduleName)' cannot depend on '\(localDependencyName)'. Allowed shared local dependencies are: \(allowedSharedLocalDependenciesList)."
+        }
+    }
+}

--- a/Tests/Sources/DependenciesValidatorTests.swift
+++ b/Tests/Sources/DependenciesValidatorTests.swift
@@ -1,0 +1,74 @@
+//  DependenciesValidatorTests.swift
+
+import XCTest
+@testable import PackageGenerator
+
+final class DependenciesValidatorTests: XCTestCase {
+    
+    func test_allDependenciesAllowed_doesNotThrow() throws {
+        let spec = Spec(
+            name: "ModuleA",
+            platforms: nil,
+            localDependencies: [
+                Spec.LocalDependency(name: "SharedUI", path: ""),
+                Spec.LocalDependency(name: "SharedNetworking", path: "")
+            ],
+            remoteDependencies: [],
+            products: [],
+            targets: [],
+            localBinaryTargets: [],
+            remoteBinaryTargets: [],
+            swiftToolsVersion: nil,
+            swiftLanguageVersions: []
+        )
+        let validator = DependenciesValidator(allowedSharedLocalDependencies: ["SharedUI", "SharedNetworking"])
+        XCTAssertNoThrow(try validator.validateSharedLocalDependencies(spec))
+    }
+    
+    func test_disallowedDependency_throwsError() throws {
+        let spec = Spec(
+            name: "ModuleA",
+            platforms: nil,
+            localDependencies: [
+                Spec.LocalDependency(name: "SharedUI", path: ""),
+                Spec.LocalDependency(name: "NotAllowedModule", path: "")
+            ],
+            remoteDependencies: [],
+            products: [],
+            targets: [],
+            localBinaryTargets: [],
+            remoteBinaryTargets: [],
+            swiftToolsVersion: nil,
+            swiftLanguageVersions: []
+        )
+        let validator = DependenciesValidator(allowedSharedLocalDependencies: ["SharedUI"])
+        do {
+            try validator.validateSharedLocalDependencies(spec)
+            XCTFail("Expected error was not thrown")
+        } catch let error as DependenciesValidatorError {
+            switch error {
+            case let .disallowedSharedLocalDependency(moduleName, localDependencyName, allowedSharedLocalDependencies):
+                XCTAssertEqual(moduleName, "ModuleA")
+                XCTAssertEqual(localDependencyName, "NotAllowedModule")
+                XCTAssertEqual(allowedSharedLocalDependencies, ["SharedUI"])
+            }
+        }
+    }
+    
+    func test_noLocalDependencies_doesNotThrow() throws {
+        let spec = Spec(
+            name: "ModuleC",
+            platforms: nil,
+            localDependencies: [],
+            remoteDependencies: [],
+            products: [],
+            targets: [],
+            localBinaryTargets: [],
+            remoteBinaryTargets: [],
+            swiftToolsVersion: nil,
+            swiftLanguageVersions: []
+        )
+        let validator = DependenciesValidator(allowedSharedLocalDependencies: ["SharedUI"])
+        XCTAssertNoThrow(try validator.validateSharedLocalDependencies(spec))
+    }
+}


### PR DESCRIPTION
## Summary

This pull request adds a new option, `--allowedSharedLocalDependencies`, to the `generate-package` command. This option lets users provide a list of allowed shared local dependencies for a package.

If the `allowedSharedLocalDependencies` array is not empty, the command will check for these dependencies in the `validate()` function. If there are any unallowed shared local dependencies in the spec file, the command will throw an error. If the `allowedSharedLocalDependencies` array is empty, the command will skip this check.

This new option is a non-breaking change, as it requires users to opt in to use it.

## Attachments

Unallowed dependency:

![image](https://github.com/user-attachments/assets/403fdf9f-09e3-4abc-a336-411a471648c9)

