### PR TITLE
Add `--quiet` flag to suppress output

### DIFF
--- a/Sources/Commands/GeneratePackage.swift
+++ b/Sources/Commands/GeneratePackage.swift
@@ -23,6 +23,9 @@ struct GeneratePackage: AsyncParsableCommand {
 
     @Option(name: .long, help: "Allowed shared local dependencies. Can be specified multiple times.")
     var allowedSharedLocalDependencies: [String] = []
+
+    @Flag(name: .long, help: "Suppress output.")
+    var quiet: Bool = false
     
     private var fileManager: FileManager { .default }
 
@@ -32,7 +35,8 @@ struct GeneratePackage: AsyncParsableCommand {
             packageDependenciesUrl: URL(filePath: packageDependencies, directoryHint: .notDirectory),
             dependencyFinder: DependencyFinder(fileManager: fileManager),
             writer: Writer(),
-            fileManager: fileManager
+            fileManager: fileManager,
+            quiet: quiet
         )
         let dependencyTreatment: Generator.DependencyTreatment = try {
             if cachingFlags.dependenciesAsBinaryTargets {

--- a/Sources/Commands/GenerateTuistPackage.swift
+++ b/Sources/Commands/GenerateTuistPackage.swift
@@ -24,6 +24,9 @@ struct GenerateTuistPackage: AsyncParsableCommand {
     @Option(name: .long, help: "Path to a folder containing the modules in individual folders (default to 'Modules'). Relative to the root of the repository. Required if targetDependencies contains local dependencies.")
     var modulesRelativePath: String = "Modules"
 
+    @Flag(name: .long, help: "Suppress output.")
+    var quiet: Bool = false
+
     private var fileManager: FileManager { .default }
 
     func run() async throws {
@@ -32,7 +35,8 @@ struct GenerateTuistPackage: AsyncParsableCommand {
             packageDependenciesUrl: URL(filePath: packageDependencies, directoryHint: .notDirectory),
             dependencyFinder: DependencyFinder(fileManager: fileManager),
             writer: Writer(),
-            fileManager: fileManager
+            fileManager: fileManager,
+            quiet: quiet
         )
         let outputPath = URL(filePath: output, directoryHint: .notDirectory)
         let targetDependenciesUrl = URL(filePath: targetDependencies, directoryHint: .notDirectory)

--- a/Sources/Core/Generator.swift
+++ b/Sources/Core/Generator.swift
@@ -19,13 +19,15 @@ struct Generator {
 
     private let writer: Writing
     private let fileManager: FileManager
-    
-    init(templateUrl: URL, packageDependenciesUrl: URL, dependencyFinder: DependencyFinding, writer: Writing, fileManager: FileManager) {
+    private let printer: Printer
+
+    init(templateUrl: URL, packageDependenciesUrl: URL, dependencyFinder: DependencyFinding, writer: Writing, fileManager: FileManager, quiet: Bool = false) {
         self.templateUrl = templateUrl
         self.packageDependenciesUrl = packageDependenciesUrl
         self.dependencyFinder = dependencyFinder
         self.writer = writer
         self.fileManager = fileManager
+        self.printer = Printer(quiet: quiet)
     }
 
     @discardableResult
@@ -45,13 +47,13 @@ struct Generator {
             folder: outputUrl,
             filename: filename
         )
-        print("✅ File successfully saved at \(outputFilePath.path).")
+        printer.print("✅ File successfully saved at \(outputFilePath.path).")
 
         switch dependencyTreatment {
         case .standard:
             return outputFilePath
         case .binaryTargets(let relativeDependenciesPath, let versionRefsPath, let exclusions):
-            print("✅ Converting \(outputFilePath) to use dependencies as binary targets.")
+            printer.print("✅ Converting \(outputFilePath) to use dependencies as binary targets.")
             let packageConvertor = PackageConvertor()
             let convertedSpec = try await packageConvertor.convertDependenciesToBinaryTargets(
                 dependencyFinder: dependencyFinder,
@@ -71,7 +73,7 @@ struct Generator {
                 folder: outputUrl,
                 filename: filename
             )
-            print("✅ File successfully updated at \(path).")
+            printer.print("✅ File successfully updated at \(path).")
             return path
         }
     }
@@ -98,7 +100,7 @@ struct Generator {
             folder: outputUrl,
             filename: Constants.packageFile
         )
-        print("✅ File successfully saved at \(outputFilePath.path).")
+        printer.print("✅ File successfully saved at \(outputFilePath.path).")
         return outputFilePath
     }
 }

--- a/Sources/Core/Printer.swift
+++ b/Sources/Core/Printer.swift
@@ -1,0 +1,11 @@
+//  Printer.swift
+
+struct Printer {
+    let quiet: Bool
+
+    func print(_ message: String) {
+        if !quiet {
+            Swift.print(message)
+        }
+    }
+}


### PR DESCRIPTION
Introduces a Printer struct that gates Swift.print calls on a quiet boolean, and exposes `--quiet` on both `generate-package` and `generate-tuist-package` commands.